### PR TITLE
Add tenanti:tinker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Command                                      | Description
  php artisan tenanti:reset {driver}          | Reset migration on each entry for a given driver.
  php artisan tenanti:refresh {driver}        | Refresh migration (reset and migrate) on each entry for a given driver.
  php artisan tenanti:queue {driver} {action} | Execute any of above action using separate queue to minimize impact on current process.
+ php artisan tenanti:tinker {driver} {id}    | Run tinker using a given driver and ID.
 
 ## Multi Database Connection Setup
 

--- a/src/CommandServiceProvider.php
+++ b/src/CommandServiceProvider.php
@@ -7,6 +7,7 @@ use Orchestra\Tenanti\Console\InstallCommand;
 use Orchestra\Tenanti\Console\MigrateCommand;
 use Orchestra\Tenanti\Console\RefreshCommand;
 use Orchestra\Tenanti\Console\RollbackCommand;
+use Orchestra\Tenanti\Console\TinkerCommand;
 use Illuminate\Contracts\Foundation\Application;
 use Orchestra\Tenanti\Console\MigrateMakeCommand;
 use Orchestra\Support\Providers\CommandServiceProvider as ServiceProvider;
@@ -26,6 +27,7 @@ class CommandServiceProvider extends ServiceProvider
         'Rollback' => 'orchestra.commands.tenanti.rollback',
         'Reset'    => 'orchestra.commands.tenanti.reset',
         'Refresh'  => 'orchestra.commands.tenanti.refresh',
+        'Tinker'   => 'orchestra.commands.tenanti.tinker',
     ];
 
     /**
@@ -129,6 +131,18 @@ class CommandServiceProvider extends ServiceProvider
     {
         $this->app->singleton('orchestra.commands.tenanti.refresh', function (Application $app) {
             return new RefreshCommand($app->make('orchestra.tenanti'));
+        });
+    }
+
+    /**
+     * Register the "tinker" migration command.
+     *
+     * @return void
+     */
+    protected function registerTinkerCommand()
+    {
+        $this->app->singleton('orchestra.commands.tenanti.tinker', function (Application $app) {
+            return new TinkerCommand($app->make('orchestra.tenanti'));
         });
     }
 }

--- a/src/CommandServiceProvider.php
+++ b/src/CommandServiceProvider.php
@@ -64,7 +64,7 @@ class CommandServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register the "install" migration command.
+     * Register the "make" migration command.
      *
      * @return void
      */

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -1,0 +1,62 @@
+<?php namespace Orchestra\Tenanti\Console;
+
+use Artisan;
+use Symfony\Component\Console\Input\InputArgument;
+
+class TinkerCommand extends BaseCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'tenanti:tinker';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run tinker using tenant connection';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $driver  = $this->argument('driver');
+        $id      = $this->argument('id');
+        $tenanti = $this->tenant->driver($driver);
+
+        $model   = $tenanti->getModel()->findOrFail($id);
+        $tenanti->asDefaultConnection($model, 'tinker');
+
+        Artisan::call('tinker');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['driver', InputArgument::REQUIRED, 'Tenant driver name'],
+            ['id', InputArgument::REQUIRED, 'Tenant model ID'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+        ];
+    }
+}


### PR DESCRIPTION
Sometime I debug Eloquent models using tinker. This works well when the model uses the default database connection.

However, when the model uses the connection resolved by Tenanti, queries cannot be done using the usual tinker method as the default connection is not yet set.

This PR adds the functionality to set the tenant default connection before executing tinker commands.

Usage:

```
php artisan tenanti:tinker {driver} {model_id}
```

Example usage:

```
php artisan tenanti:tinker franchise 1
```
