### PR TITLE
Add console command shortcuts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "autoload-dev": {
         "classmap": [
+            "tests",
             "tests/stubs"
         ]
     },
@@ -27,7 +28,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.4",
-        "laravel/framework": "~5.3.0"
+        "laravel/framework": "~5.3.0",
+        "orchestra/testbench": "~3.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -5,6 +5,7 @@ namespace Orchestra\Tenanti\Console;
 use Illuminate\Console\Command;
 use Orchestra\Tenanti\TenantiManager;
 use Orchestra\Tenanti\Migrator\FactoryInterface;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -49,6 +50,44 @@ abstract class BaseCommand extends Command
     }
 
     /**
+     * Get driver argument or first driver in the config.
+     *
+     * @return string
+     */
+    protected function getDriver()
+    {
+        $argument = $this->argument('driver');
+
+        if (!empty($argument)) {
+            return $argument;
+        }
+
+        $driver = $this->getDriverFromConfig();
+
+        if (!empty($driver)) {
+            return $driver;
+        }
+
+        throw new RuntimeException('Not enough arguments (missing: "driver").');
+    }
+
+    /**
+     * Get first driver in the config.
+     *
+     * @return string
+     */
+    protected function getDriverFromConfig()
+    {
+        $drivers = array_keys($this->tenant->getConfig('drivers'));
+
+        if (count($drivers) === 1) {
+            return $drivers[0];
+        }
+
+        return null;
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array
@@ -56,7 +95,7 @@ abstract class BaseCommand extends Command
     protected function getArguments()
     {
         return [
-            ['driver', InputArgument::REQUIRED, 'Tenant driver name.'],
+            ['driver', InputArgument::OPTIONAL, 'Tenant driver name.'],
         ];
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -27,7 +27,7 @@ class InstallCommand extends BaseCommand
      */
     public function handle()
     {
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $database = $this->option('database');
         $id       = $this->option('id');
 

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -33,7 +33,7 @@ class MigrateCommand extends BaseCommand
             return;
         }
 
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $database = $this->option('database');
         $id       = $this->option('id');
         $pretend  = $this->option('pretend', false);

--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -6,7 +6,6 @@ use Orchestra\Support\Str;
 use Illuminate\Support\Composer;
 use Orchestra\Tenanti\TenantiManager;
 use Orchestra\Tenanti\Migrator\Creator;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -60,22 +59,9 @@ class MigrateMakeCommand extends BaseCommand
      */
     public function handle()
     {
-        $arg1 = $this->argument('driver');
-        $arg2 = $this->argument('name');
-
-        if (empty($arg1) && empty($arg2)) {
-            throw new RuntimeException('Not enough arguments (missing: "driver, name").');
-        } else if (empty($arg2)) {
-            $name = $arg1;
-            $driver = $this->getDriverFromConfig();
-
-            if (empty($driver)) {
-                throw new RuntimeException('Not enough arguments (missing: "driver").');
-            }
-        } else {
-            $name = $arg2;
-            $driver = $arg1;
-        }
+        $arguments = $this->getArgumentsWithDriver('name');
+        $driver = $arguments['driver'];
+        $name = $arguments['name'];
 
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs

--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -6,6 +6,7 @@ use Orchestra\Support\Str;
 use Illuminate\Support\Composer;
 use Orchestra\Tenanti\TenantiManager;
 use Orchestra\Tenanti\Migrator\Creator;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -59,11 +60,26 @@ class MigrateMakeCommand extends BaseCommand
      */
     public function handle()
     {
+        $arg1 = $this->argument('driver');
+        $arg2 = $this->argument('name');
+
+        if (empty($arg1) && empty($arg2)) {
+            throw new RuntimeException('Not enough arguments (missing: "driver, name").');
+        } else if (empty($arg2)) {
+            $name = $arg1;
+            $driver = $this->getDriverFromConfig();
+
+            if (empty($driver)) {
+                throw new RuntimeException('Not enough arguments (missing: "driver").');
+            }
+        } else {
+            $name = $arg2;
+            $driver = $arg1;
+        }
+
         // It's possible for the developer to specify the tables to modify in this
         // schema operation. The developer may also specify if this table needs
         // to be freshly created so we can create the appropriate migrations.
-        $driver = $this->input->getArgument('driver');
-        $name   = $this->input->getArgument('name');
         $create = $this->input->getOption('create');
         $table  = $this->input->getOption('table');
 
@@ -118,8 +134,8 @@ class MigrateMakeCommand extends BaseCommand
     protected function getArguments()
     {
         return [
-            ['driver', InputArgument::REQUIRED, 'Tenant driver name.'],
-            ['name', InputArgument::REQUIRED, 'The name of the migration'],
+            ['driver', InputArgument::OPTIONAL, 'Tenant driver name.'],
+            ['name', InputArgument::OPTIONAL, 'The name of the migration'],
         ];
     }
 

--- a/src/Console/QueuedCommand.php
+++ b/src/Console/QueuedCommand.php
@@ -46,7 +46,7 @@ class QueuedCommand extends BaseCommand
             return;
         }
 
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $action   = $this->argument('action');
         $database = $this->option('database');
 

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -33,7 +33,7 @@ class RefreshCommand extends BaseCommand
             return;
         }
 
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $database = $this->option('database');
         $id       = $this->option('id');
 

--- a/src/Console/ResetCommand.php
+++ b/src/Console/ResetCommand.php
@@ -33,7 +33,7 @@ class ResetCommand extends BaseCommand
             return;
         }
 
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $database = $this->option('database');
         $id       = $this->option('id');
         $pretend  = $this->option('pretend', false);

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -33,7 +33,7 @@ class RollbackCommand extends BaseCommand
             return;
         }
 
-        $driver   = $this->argument('driver');
+        $driver   = $this->getDriver();
         $database = $this->option('database');
         $id       = $this->option('id');
         $pretend  = $this->option('pretend', false);

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -2,7 +2,6 @@
 
 namespace Orchestra\Tenanti\Console;
 
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends BaseCommand
@@ -28,22 +27,9 @@ class TinkerCommand extends BaseCommand
      */
     public function handle()
     {
-        $arg1 = $this->argument('driver');
-        $arg2 = $this->argument('id');
-
-        if (empty($arg1) && empty($arg2)) {
-            throw new RuntimeException('Not enough arguments (missing: "driver, id").');
-        } else if (empty($arg2)) {
-            $id = $arg1;
-            $driver = $this->getDriverFromConfig();
-
-            if (empty($driver)) {
-                throw new RuntimeException('Not enough arguments (missing: "driver").');
-            }
-        } else {
-            $id = $arg2;
-            $driver = $arg1;
-        }
+        $arguments = $this->getArgumentsWithDriver('id');
+        $driver = $arguments['driver'];
+        $id = $arguments['id'];
 
         $tenanti = $this->tenant->driver($driver);
 

--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -2,6 +2,7 @@
 
 namespace Orchestra\Tenanti\Console;
 
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 
 class TinkerCommand extends BaseCommand
@@ -27,8 +28,23 @@ class TinkerCommand extends BaseCommand
      */
     public function handle()
     {
-        $driver  = $this->argument('driver');
-        $id      = $this->argument('id');
+        $arg1 = $this->argument('driver');
+        $arg2 = $this->argument('id');
+
+        if (empty($arg1) && empty($arg2)) {
+            throw new RuntimeException('Not enough arguments (missing: "driver, id").');
+        } else if (empty($arg2)) {
+            $id = $arg1;
+            $driver = $this->getDriverFromConfig();
+
+            if (empty($driver)) {
+                throw new RuntimeException('Not enough arguments (missing: "driver").');
+            }
+        } else {
+            $id = $arg2;
+            $driver = $arg1;
+        }
+
         $tenanti = $this->tenant->driver($driver);
 
         $model   = $tenanti->getModel()->findOrFail($id);
@@ -45,8 +61,8 @@ class TinkerCommand extends BaseCommand
     protected function getArguments()
     {
         return [
-            ['driver', InputArgument::REQUIRED, 'Tenant driver name.'],
-            ['id', InputArgument::REQUIRED, 'The entity ID.'],
+            ['driver', InputArgument::OPTIONAL, 'Tenant driver name.'],
+            ['id', InputArgument::OPTIONAL, 'The entity ID.'],
         ];
     }
 }

--- a/src/Migrator/Migrator.php
+++ b/src/Migrator/Migrator.php
@@ -2,7 +2,6 @@
 
 namespace Orchestra\Tenanti\Migrator;
 
-use Illuminate\Support\Arr;
 use Orchestra\Tenanti\Migration;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Migrations\Migrator as BaseMigrator;

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -1,0 +1,52 @@
+<?php namespace Orchestra\Tenanti\TestCase\Console;
+
+use Illuminate\Support\Composer;
+use Mockery as m;
+use Orchestra\Tenanti\CommandServiceProvider;
+use Orchestra\Tenanti\Migrator\Creator;
+use Orchestra\Tenanti\Migrator\FactoryInterface;
+use Orchestra\Tenanti\TenantiManager;
+use Orchestra\Tenanti\TestCase\Kernel;
+use Orchestra\Testbench\TestCase;
+
+abstract class CommandTest extends TestCase
+{
+    protected function getMockDriverFactory() {
+        $factory = m::mock(FactoryInterface::class);
+
+        $factory->shouldReceive('install');
+
+        $factory->shouldReceive('getNotes')
+            ->andReturn([]);
+
+        $factory->shouldReceive('flushNotes');
+
+        $factory->shouldReceive('run');
+
+        return $factory;
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            CommandServiceProvider::class,
+        ];
+    }
+
+    protected function resolveApplicationConsoleKernel($app)
+    {
+        $app->singleton('artisan', function ($app) {
+            return new \Illuminate\Console\Application($app, $app['events'], $app->version());
+        });
+
+        $app->singleton('Illuminate\Contracts\Console\Kernel', Kernel::class);
+
+        $app['orchestra.tenanti.creator'] = m::mock(Creator::class);
+        $app['orchestra.tenanti'] = m::mock(TenantiManager::class);
+    }
+
+    public function artisan($command, $parameters = [])
+    {
+        parent::artisan($command, array_merge($parameters, ['--no-interaction' => true]));
+    }
+}

--- a/tests/Console/MigrateCommandTest.php
+++ b/tests/Console/MigrateCommandTest.php
@@ -1,0 +1,95 @@
+<?php namespace Orchestra\Tenanti\TestCase\Console;
+
+use Mockery as m;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class MigrateCommandTest extends CommandTest
+{
+    public function testMigrateWithoutAnyDrivers()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([]);
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateCommand[prepareDatabase]', [$tenanti]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver"');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:migrate');
+    }
+
+    public function testMigrateWithExistingDriver()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('driver')
+            ->with('driver')
+            ->andReturn($this->getMockDriverFactory());
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateCommand[prepareDatabase]', [$tenanti]);
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:migrate', ['driver' => 'driver']);
+    }
+
+    public function testMigrateWithNonExistingDriver()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('driver')
+            ->with('ghost')
+            ->andThrow(RuntimeException::class, 'Driver [ghost] not supported.');
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateCommand[prepareDatabase]', [$tenanti]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('[ghost] not supported');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:migrate', ['driver' => 'ghost']);
+    }
+
+    public function testMigrateWithoutDriverArgumentAndGetFromConfig()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant' => [
+                ],
+            ]);
+
+        $tenanti->shouldReceive('driver')
+            ->with('tenant')
+            ->andReturn($this->getMockDriverFactory());
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateCommand[prepareDatabase]', [$tenanti]);
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:migrate');
+    }
+
+    public function testMigrateWithoutDriverArgumentAndRejectFromConfig()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+                'tenant2' => [
+                ],
+            ]);
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateCommand[prepareDatabase]', [$tenanti]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver"');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:migrate');
+    }
+}

--- a/tests/Console/MigrateMakeCommandTest.php
+++ b/tests/Console/MigrateMakeCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Orchestra\Tenanti\TestCase\Console;
+
+use Illuminate\Support\Composer;
+use Mockery as m;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class MigrateMakeCommandTest extends CommandTest
+{
+    public function testMakeWithoutAnyDrivers()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+        $creator = $this->app['orchestra.tenanti.creator'];
+        $composer = m::mock(Composer::class);
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([]);
+
+        $command = m::mock('\Orchestra\Tenanti\Console\MigrateMakeCommand[call]', [$tenanti, $creator, $composer]);
+        $command->shouldReceive('call');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver, name"');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:make');
+    }
+
+    public function testMakeWithOneDriverWithOneArgument()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+        $creator = $this->app['orchestra.tenanti.creator'];
+
+        $composer = m::mock(Composer::class);
+        $composer->shouldReceive('dumpAutoloads');
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant' => [
+                ],
+            ]);
+
+        $factory = $this->getMockDriverFactory();
+
+        $tenanti->shouldReceive('driver')
+            ->with('tenant')
+            ->andReturn($factory);
+
+        $command = m::mock('Orchestra\Tenanti\Console\MigrateMakeCommand[writeMigration]',
+            [$tenanti, $creator, $composer])
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('writeMigration')
+            ->withArgs(['tenant', 'add_migration', null, null])
+            ->once();
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:make', ['driver' => 'add_migration']);
+    }
+
+    public function testTinkerWithOneDriverWithTwoArguments()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+        $creator = $this->app['orchestra.tenanti.creator'];
+
+        $composer = m::mock(Composer::class);
+        $composer->shouldReceive('dumpAutoloads');
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+            ]);
+
+        $command = m::mock('Orchestra\Tenanti\Console\MigrateMakeCommand[writeMigration]',
+            [$tenanti, $creator, $composer])
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('writeMigration')
+            ->withArgs(['tenant1', 'add_migration', null, null])
+            ->once();
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:make', ['driver' => 'tenant1', 'name' => 'add_migration']);
+    }
+
+    public function testTinkerWithTwoDriversWithOneArgument()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+        $creator = $this->app['orchestra.tenanti.creator'];
+
+        $composer = m::mock(Composer::class);
+        $composer->shouldReceive('dumpAutoloads');
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+                'tenant2' => [
+                ],
+            ]);
+
+        $command = m::mock('Orchestra\Tenanti\Console\MigrateMakeCommand[writeMigration]',
+            [$tenanti, $creator, $composer])
+            ->shouldAllowMockingProtectedMethods();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver"');
+
+        $command->shouldNotReceive('writeMigration');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:make', ['driver' => 'add_migration']);
+    }
+
+    public function testTinkerWithTwoDriversWithTwoArguments()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+        $creator = $this->app['orchestra.tenanti.creator'];
+
+        $composer = m::mock(Composer::class);
+        $composer->shouldReceive('dumpAutoloads');
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+                'tenant2' => [
+                ],
+            ]);
+
+        $command = m::mock('Orchestra\Tenanti\Console\MigrateMakeCommand[writeMigration]',
+            [$tenanti, $creator, $composer])
+            ->shouldAllowMockingProtectedMethods();
+
+        $command->shouldReceive('writeMigration')
+            ->withArgs(['tenant2', 'add_migration', null, null])
+            ->once();
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:make', ['driver' => 'tenant2', 'name' => 'add_migration']);
+    }
+}

--- a/tests/Console/TinkerCommandTest.php
+++ b/tests/Console/TinkerCommandTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Orchestra\Tenanti\TestCase\Console;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Mockery as m;
+use Symfony\Component\Console\Exception\RuntimeException;
+
+class TinkerCommandTest extends CommandTest
+{
+
+    public function testTinkerWithoutAnyDrivers()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([]);
+
+        $command = m::mock('\Orchestra\Tenanti\Console\TinkerCommand[call]', [$tenanti]);
+        $command->shouldReceive('call');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver, id"');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:tinker');
+    }
+
+    public function testTinkerWithOneDriverWithOneArgument()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant' => [
+                ],
+            ]);
+
+        $model = m::mock(Model::class);
+
+        $model->shouldReceive('findOrFail')
+            ->with('1');
+
+        $factory = $this->getMockDriverFactory();
+
+        $factory->shouldReceive('getModel')
+            ->andReturn($model);
+
+        $factory->shouldReceive('asDefaultConnection')
+            ->withAnyArgs();
+
+        $tenanti->shouldReceive('driver')
+            ->with('tenant')
+            ->andReturn($factory);
+
+        $command = m::mock('Orchestra\Tenanti\Console\TinkerCommand[call]', [$tenanti]);
+        $command->shouldReceive('call');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:tinker', ['driver' => '1']);
+    }
+
+    public function testTinkerWithOneDriverWithWrongModel()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant' => [
+                ],
+            ]);
+
+        $model = m::mock(Model::class);
+
+        $model->shouldReceive('findOrFail')
+            ->with('1')
+            ->andThrow(ModelNotFoundException::class);
+
+        $factory = $this->getMockDriverFactory();
+
+        $factory->shouldReceive('getModel')
+            ->andReturn($model);
+
+        $tenanti->shouldReceive('driver')
+            ->with('tenant')
+            ->andReturn($factory);
+
+        $command = m::mock('Orchestra\Tenanti\Console\TinkerCommand[call]', [$tenanti]);
+        $this->expectException(ModelNotFoundException::class);
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:tinker', ['driver' => '1']);
+    }
+
+    public function testTinkerWithTwoDriversWithOneArgument()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+                'tenant2' => [
+                ],
+            ]);
+
+        $command = m::mock('Orchestra\Tenanti\Console\TinkerCommand[call]', [$tenanti]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing: "driver"');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:tinker', ['driver' => '1']);
+    }
+
+    public function testTinkerWithTwoDriversWithTwoArguments()
+    {
+        $tenanti = $this->app['orchestra.tenanti'];
+
+        $tenanti->shouldReceive('getConfig')
+            ->andReturn([
+                'tenant1' => [
+                ],
+                'tenant2' => [
+                ],
+            ]);
+
+        $model = m::mock(Model::class);
+
+        $model->shouldReceive('findOrFail')
+            ->with('1');
+
+        $factory = $this->getMockDriverFactory();
+
+        $factory->shouldReceive('getModel')
+            ->andReturn($model);
+
+        $factory->shouldReceive('asDefaultConnection')
+            ->withAnyArgs();
+
+        $tenanti->shouldReceive('driver')
+            ->with('tenant2')
+            ->andReturn($factory);
+
+        $command = m::mock('Orchestra\Tenanti\Console\TinkerCommand[call]', [$tenanti]);
+        $command->shouldReceive('call');
+
+        $this->app['artisan']->add($command);
+        $this->artisan('tenanti:tinker', ['driver' => 'tenant2', 'id' => 1]);
+    }
+}

--- a/tests/Kernel.php
+++ b/tests/Kernel.php
@@ -1,0 +1,39 @@
+<?php namespace Orchestra\Tenanti\TestCase;
+
+use Exception;
+
+class Kernel extends \Illuminate\Foundation\Console\Kernel
+{
+    /**
+     * The bootstrap classes for the application.
+     *
+     * @return void
+     */
+    protected $bootstrappers = [];
+
+    /**
+     * The Artisan commands provided by your application.
+     *
+     * @var array
+     */
+    protected $commands = [];
+
+    /**
+     * Report the exception to the exception handler.
+     *
+     * @param  \Exception $e
+     *
+     * @return void
+     *
+     * @throws \Exception
+     */
+    protected function reportException(Exception $e)
+    {
+        throw $e;
+    }
+
+    public function getArtisan()
+    {
+        return $this->app['artisan'];
+    }
+}


### PR DESCRIPTION
This PR adds command shortcuts that are useful for those that only have a single type of driver.

Example Tenanti config:
```php
'drivers' => [
    'tenant-a' => [
        // ...
    ],
]
```

Shortcuts:
```
php artisan tenanti:make add_tenant_migration
php artisan tenanti:migrate
php artisan tenanti:tinker 1
```

Equivalent commands:
```
php artisan tenanti:make tenant-a add_tenant_migration
php artisan tenanti:migrate tenant-a
php artisan tenanti:tinker tenant-a 1
```