### PR TITLE
Add dynamic migrations

### DIFF
--- a/src/Migrator/Factory.php
+++ b/src/Migrator/Factory.php
@@ -170,7 +170,7 @@ class Factory implements FactoryContract
 
         $migrator->setConnection($database);
         $migrator->setEntity($entity);
-        $migrator->run((array) $this->getMigrationPath(), ['pretend' => (bool) $pretend]);
+        $migrator->run((array) $this->getMigrationPath($entity), ['pretend' => (bool) $pretend]);
         $migrator->resetConnection();
 
         $this->mergeMigratorNotes($migrator);
@@ -193,7 +193,7 @@ class Factory implements FactoryContract
 
         $migrator->setConnection($database);
         $migrator->setEntity($entity);
-        $migrator->rollback((array) $this->getMigrationPath(), ['pretend' => (bool) $pretend]);
+        $migrator->rollback((array) $this->getMigrationPath($entity), ['pretend' => (bool) $pretend]);
         $migrator->resetConnection();
 
         $this->mergeMigratorNotes($migrator);
@@ -216,7 +216,7 @@ class Factory implements FactoryContract
 
         $migrator->setConnection($database);
         $migrator->setEntity($entity);
-        $migrator->reset((array) $this->getMigrationPath(), $pretend);
+        $migrator->reset((array) $this->getMigrationPath($entity), $pretend);
         $migrator->resetConnection();
 
         $this->mergeMigratorNotes($migrator);

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -259,7 +259,7 @@ trait Operation
      *
      * @return string|array|null
      */
-    public function getMigrationPath($entity = null)
+    public function getMigrationPath(Model $entity = null)
     {
         if ($entity !== null && isset($this->migrationPaths[$entity->getKey()])) {
             return array_merge([$this->getConfig('path')], $this->migrationPaths[$entity->getKey()]);
@@ -318,19 +318,20 @@ trait Operation
     /**
      * Load migrations from a specific path.
      *
-     * @param  string|array  $path
+     * @param  string|array  $paths
      * @param  \Illuminate\Database\Eloquent\Model  $entity
      *
      * @return null
      */
-    public function loadMigrationsFrom($path, $entity) {
+    public function loadMigrationsFrom($paths, Model $entity)
+    {
         $id = $entity->getKey();
 
         if (! isset($this->migrationPaths[$id])) {
             $this->migrationPaths[$id] = [];
         }
 
-        $this->migrationPaths[$id] = array_merge($this->migrationPaths[$id], is_array($path) ? $path : [$path]);
+        $this->migrationPaths[$id] = array_merge($this->migrationPaths[$id], (array) $paths);
         $this->migrationPaths[$id] = array_unique($this->migrationPaths[$id]);
     }
 }

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -259,7 +259,11 @@ trait Operation
      */
     public function getMigrationPath()
     {
-        return array_merge([$this->getConfig('path')], $this->migrationPaths);
+        if (! empty($this->migrationPaths)) {
+            return array_merge([$this->getConfig('path')], $this->migrationPaths);
+        }
+
+        return $this->getConfig('path');
     }
 
     /**

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -210,7 +210,7 @@ trait Operation
                 'entity'     => $entity,
                 'template'   => $tenants['template'],
                 'connection' => $connection,
-                'migrator'    => $this,
+                'migrator'   => $this,
             ]);
 
             $repository->set($name, $config);

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -47,6 +47,13 @@ trait Operation
     protected $data = [];
 
     /**
+     * Paths that will be added to the migration.
+     *
+     * @var array
+     */
+    protected $migrationPaths = [];
+
+    /**
      * Resolver list.
      *
      * @var array
@@ -203,6 +210,7 @@ trait Operation
                 'entity'     => $entity,
                 'template'   => $tenants['template'],
                 'connection' => $connection,
+                'factory'    => $this,
             ]);
 
             $repository->set($name, $config);
@@ -251,7 +259,7 @@ trait Operation
      */
     public function getMigrationPath()
     {
-        return $this->getConfig('path');
+        return array_merge([$this->getConfig('path')], $this->migrationPaths);
     }
 
     /**
@@ -299,5 +307,17 @@ trait Operation
         }
 
         return Str::replace($name, $this->data[$id]);
+    }
+
+    /**
+     * Load migrations from a specific path.
+     *
+     * @param  string|array  $path
+     *
+     * @return null
+     */
+    public function loadMigrationsFrom($path) {
+        $this->migrationPaths = array_merge($this->migrationPaths, is_array($path) ? $path : [$path]);
+        $this->migrationPaths = array_unique($this->migrationPaths);
     }
 }

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -255,12 +255,14 @@ trait Operation
     /**
      * Get migration path.
      *
-     * @return mixed
+     * @param  \Illuminate\Database\Eloquent\Model|null  $entity
+     *
+     * @return string|array|null
      */
-    public function getMigrationPath()
+    public function getMigrationPath($entity = null)
     {
-        if (! empty($this->migrationPaths)) {
-            return array_merge([$this->getConfig('path')], $this->migrationPaths);
+        if ($entity !== null && isset($this->migrationPaths[$entity->getKey()])) {
+            return array_merge([$this->getConfig('path')], $this->migrationPaths[$entity->getKey()]);
         }
 
         return $this->getConfig('path');
@@ -317,11 +319,18 @@ trait Operation
      * Load migrations from a specific path.
      *
      * @param  string|array  $path
+     * @param  \Illuminate\Database\Eloquent\Model  $entity
      *
      * @return null
      */
-    public function loadMigrationsFrom($path) {
-        $this->migrationPaths = array_merge($this->migrationPaths, is_array($path) ? $path : [$path]);
-        $this->migrationPaths = array_unique($this->migrationPaths);
+    public function loadMigrationsFrom($path, $entity) {
+        $id = $entity->getKey();
+
+        if (! isset($this->migrationPaths[$id])) {
+            $this->migrationPaths[$id] = [];
+        }
+
+        $this->migrationPaths[$id] = array_merge($this->migrationPaths[$id], is_array($path) ? $path : [$path]);
+        $this->migrationPaths[$id] = array_unique($this->migrationPaths[$id]);
     }
 }

--- a/src/Migrator/Operation.php
+++ b/src/Migrator/Operation.php
@@ -210,7 +210,7 @@ trait Operation
                 'entity'     => $entity,
                 'template'   => $tenants['template'],
                 'connection' => $connection,
-                'factory'    => $this,
+                'migrator'    => $this,
             ]);
 
             $repository->set($name, $config);

--- a/tests/Migrator/OperationTest.php
+++ b/tests/Migrator/OperationTest.php
@@ -237,6 +237,20 @@ class OperationTest extends TestCase
 
         $this->manager = $manager;
 
+        $model = m::mock('\Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('getKey')->andReturn(5);
+        $this->loadMigrationsFrom('customPath', $model);
+        $this->assertEquals([$path, 'customPath'], $this->getMigrationPath($model));
+
+        $model2 = m::mock('\Illuminate\Database\Eloquent\Model');
+        $model2->shouldReceive('getKey')->andReturn(6);
+        $this->loadMigrationsFrom(['customPath', 'customPath2'], $model2);
+        $this->assertEquals([$path, 'customPath', 'customPath2'], $this->getMigrationPath($model2));
+
+        $model3 = m::mock('\Illuminate\Database\Eloquent\Model');
+        $model3->shouldReceive('getKey')->andReturn(7);
+        $this->assertEquals($path, $this->getMigrationPath($model3));
+
         $this->assertEquals($path, $this->getMigrationPath());
     }
 


### PR DESCRIPTION
**Usecase**

User many to many Modules
For each User I want to migrate just the modules that the user owns, for that I would need to call ``` loadMigrationsFrom ``` however that's not possible since ``` tenanti:migrate ``` runs it's own separate migrator.

This PR add's a method ``` loadMigrationsFrom ``` to the Operation trait (Factory class), and also injects the Factory class on the ServiceProvider callback, this way we can load migrations dynamically, example:

```php
Tenanti::connection('tenants', function (User $entity, array $config, $database, $factory) {
            User::$tenant = $entity;

            $this->mapMigrations($entity, $factory);

            $config['database'] = $entity->database;

            return $config;
        });
```

```php
public function mapMigrations($entity, $factory) {
        $modules = $entity->modules;

        if($modules->first() !== null) {
            foreach ($modules as $m) {
                $factory->loadMigrationsFrom($m->migrationPath, $entity);
            }
        }
    }
```