### PR TITLE
Give devs a better Tenanti install experience

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,15 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.5-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Orchestra\\Tenanti\\TenantiServiceProvider",
+                "Orchestra\\Tenanti\\CommandServiceProvider"
+            ],
+            "aliases": {
+                "Tenati": "Orchestra\\Support\\Facades\\Tenanti"
+            }
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
                 "Orchestra\\Tenanti\\CommandServiceProvider"
             ],
             "aliases": {
-                "Tenati": "Orchestra\\Support\\Facades\\Tenanti"
+                "Tenanti": "Orchestra\\Support\\Facades\\Tenanti"
             }
         }
     },


### PR DESCRIPTION
Add laravel providers and aliases to extra key in composer.json. This will allow for Laravel to easily auto-discover the packages and remove the requirement for developers to manually add the providers and aliases to their app.