### PR TITLE
[3.5] Fix too many connections issue in multi-database setup

### DIFF
--- a/src/Migrator/Factory.php
+++ b/src/Migrator/Factory.php
@@ -124,8 +124,8 @@ class Factory implements FactoryContract
     {
         $database = $this->asConnection($entity, $database);
         $table = $this->resolveMigrationTableName($entity);
-
-        $repository = $this->resolveMigrator($table)->getRepository();
+        $migrator = $this->resolveMigrator($table);
+        $repository = $migrator->getRepository();
 
         $repository->setSource($database);
 
@@ -134,6 +134,10 @@ class Factory implements FactoryContract
 
             $this->note("<info>Migration table {$table} created successfully.</info>");
         }
+
+        $migrator->setConnection($database);
+        $migrator->setEntity($entity);
+        $migrator->resetConnection();
     }
 
     /**

--- a/tests/Unit/Migrator/FactoryTest.php
+++ b/tests/Unit/Migrator/FactoryTest.php
@@ -285,6 +285,9 @@ class FactoryTest extends TestCase
         $app['schema']->shouldReceive('hasTable')->once()->with('user_5_migrations')->andReturn(false)
             ->shouldReceive('create')->once()->with('user_5_migrations', m::type('Closure'))->andReturnNull();
 
+        $app['db']->shouldReceive('getDefaultConnection')->once()->andReturnNull()
+            ->shouldReceive('setDefaultConnection')->once()->with('primary');
+
         $model = $this->getMockModel();
 
         $manager->shouldReceive('getConfig')->with('user.connection', null)->andReturnNull()
@@ -312,7 +315,9 @@ class FactoryTest extends TestCase
             ->shouldReceive('create')->once()->with('migrations', m::type('Closure'))->andReturnNull();
 
         $app['db']->shouldReceive('connection')->with('tenant_foo')->andReturnSelf()
-            ->shouldReceive('getSchemaBuilder')->andReturn($app['schema']);
+            ->shouldReceive('getSchemaBuilder')->andReturn($app['schema'])
+            ->shouldReceive('getDefaultConnection')->once()->andReturnNull()
+            ->shouldReceive('setDefaultConnection')->once()->with('tenant_foo');
 
         $stub = new Factory($app, $manager, $driver);
         $model = $this->getMockModel();


### PR DESCRIPTION
Fixes #58 

After some debugging, it was found that connections to the databases were retained during `runInstall`.

![screenshot 2018-10-31 at 4 13 25 pm](https://user-images.githubusercontent.com/866735/47774520-33a9da80-dd28-11e8-87b3-98e78ef3f1a6.png)

This PR allows those database connections to be disconnected after running `runInstall`.