### PR TITLE
Fixing Method Illuminate\Support\Str::replace does not exist.

### DIFF
--- a/src/Migrator/MigrationWriter.php
+++ b/src/Migrator/MigrationWriter.php
@@ -4,7 +4,7 @@ namespace Orchestra\Tenanti\Migrator;
 
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
+use Orchestra\Support\Str;
 use Orchestra\Tenanti\TenantiManager;
 
 class MigrationWriter extends MigrationCreator


### PR DESCRIPTION
Fixing Method Illuminate\Support\Str::replace does not exist when trying to create tenanti migration.