### PR TITLE
Fix Call to undefined method Orchestra\Tenanti\Migrator\Factory::getModel()

### DIFF
--- a/src/Console/TinkerCommand.php
+++ b/src/Console/TinkerCommand.php
@@ -31,7 +31,7 @@ class TinkerCommand extends BaseCommand
 
         \tap($this->tenantDriver($arguments['driver']), static function ($tenanti) use ($arguments) {
             $tenanti->asDefaultConnection(
-                $tenanti->getModel()->findOrFail($arguments['id']), 'tinker'
+                $tenanti->model()->findOrFail($arguments['id']), 'tinker'
             );
         });
 

--- a/tests/Unit/Console/TinkerCommandTest.php
+++ b/tests/Unit/Console/TinkerCommandTest.php
@@ -39,7 +39,7 @@ class TinkerCommandTest extends CommandTest
 
         $factory = $this->getMockDriverFactory();
 
-        $factory->shouldReceive('getModel')
+        $factory->shouldReceive('model')
             ->andReturn($model);
 
         $factory->shouldReceive('asDefaultConnection')
@@ -74,7 +74,7 @@ class TinkerCommandTest extends CommandTest
 
         $factory = $this->getMockDriverFactory();
 
-        $factory->shouldReceive('getModel')
+        $factory->shouldReceive('model')
             ->andReturn($model);
 
         $tenanti->shouldReceive('driver')
@@ -126,7 +126,7 @@ class TinkerCommandTest extends CommandTest
 
         $factory = $this->getMockDriverFactory();
 
-        $factory->shouldReceive('getModel')
+        $factory->shouldReceive('model')
             ->andReturn($model);
 
         $factory->shouldReceive('asDefaultConnection')


### PR DESCRIPTION
Fix error when invoking **tenanti:tinker** command